### PR TITLE
Introduce some minor fixes and enhancements

### DIFF
--- a/src/renderer/data/constants.ts
+++ b/src/renderer/data/constants.ts
@@ -1,1 +1,2 @@
+export const FONTAWESOME_BASEURL = "https://kit-pro.fontawesome.com/releases/v5.15.2/css/pro.min.css";
 export const MONACO_BASEURL = "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min";

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../types.d.ts" />
+import {Constants} from "@data";
 import {DiscordModules, DOM} from "@modules";
 import * as IPCEvents from "@common/ipcevents";
 import {require as Require, path} from "@node";
@@ -29,6 +30,7 @@ export default new class PCCompat {
         });
 
         DOM.injectCSS("core", Require(path.resolve(PCCompatNative.getBasePath(), "src/renderer/styles", "index.scss")));
+        DOM.injectCSS("font-awesome", Constants.FONTAWESOME_BASEURL, {type: "URL", documentHead: true});
 
         SettingsRenderer.patchSettingsView();
         QuickCSS.initialize();

--- a/src/renderer/modules/datastore.ts
+++ b/src/renderer/modules/datastore.ts
@@ -33,13 +33,14 @@ const DataStore = new class DataStore extends Store<"misc" | "data-update"> {
             const location = path.resolve(this.configFolder, `${name}.json`);
             if (!fs.existsSync(location)) return def;
             const data = Require(location);
+            if (Object.keys(data).length === 0) return def;
             this.cache.set(name, data);
             return data;
         } catch (error) {
             Logger.error(`Data of ${name} corrupt:`, error);
             return def;
         }
-    } 
+    }
 
     trySaveData(name: string, data: any, emit?: boolean, event: any = "data-update") {
         this.cache.set(name, data);

--- a/src/renderer/powercord/components/icons/FontAwesome.tsx
+++ b/src/renderer/powercord/components/icons/FontAwesome.tsx
@@ -3,8 +3,8 @@ const stylePrefixes = ["far", "fal", "fad", "fab"];
 
 export default (props) => {
     const style = styles.find(style => style === props.icon.split(" ")[0].match(/[a-z]+(?!.*-)/)[0]);
-    const stylePrefix = stylePrefixes[style] ?? "fas";
+    const stylePrefix = stylePrefixes[styles.indexOf(style)] ?? "fas";
     const iconName = props.icon.replace(`-${style}`, "");
 
-    return <span className={`${stylePrefix} fa-${iconName} ${props.className}`.trim()} />
+    return <span className={`${stylePrefix} fa-${iconName} ${props.className ?? ""}`.trim()} />
 };

--- a/src/renderer/powercord/components/icons/FontAwesome.tsx
+++ b/src/renderer/powercord/components/icons/FontAwesome.tsx
@@ -1,3 +1,5 @@
+import { joinClassNames } from "@modules/utilities";
+
 const styles = ["regular", "light", "duotone", "brands"];
 const stylePrefixes = ["far", "fal", "fad", "fab"];
 
@@ -6,5 +8,5 @@ export default (props) => {
     const stylePrefix = stylePrefixes[styles.indexOf(style)] ?? "fas";
     const iconName = props.icon.replace(`-${style}`, "");
 
-    return <span className={`${stylePrefix} fa-${iconName} ${props.className ?? ""}`.trim()} />
+    return <span className={joinClassNames(stylePrefix, `fa-${iconName}`, props.className ?? "").trim()} />
 };

--- a/src/renderer/powercord/components/icons/FontAwesome.tsx
+++ b/src/renderer/powercord/components/icons/FontAwesome.tsx
@@ -1,0 +1,10 @@
+const styles = ["regular", "light", "duotone", "brands"];
+const stylePrefixes = ["far", "fal", "fad", "fab"];
+
+export default (props) => {
+    const style = styles.find(style => style === props.icon.split(" ")[0].match(/[a-z]+(?!.*-)/)[0]);
+    const stylePrefix = stylePrefixes[style] ?? "fas";
+    const iconName = props.icon.replace(`-${style}`, "");
+
+    return <span className={`${stylePrefix} fa-${iconName} ${props.className}`.trim()} />
+};

--- a/src/renderer/powercord/components/icons/FrontAwesome.tsx
+++ b/src/renderer/powercord/components/icons/FrontAwesome.tsx
@@ -1,1 +1,0 @@
-export default () => null;

--- a/src/renderer/powercord/components/icons/index.ts
+++ b/src/renderer/powercord/components/icons/index.ts
@@ -35,4 +35,4 @@ export { default as Unlink } from "./Unlink";
 export { default as Unpin } from "./Unpin";
 export { default as Verified } from "./Verified";
 export { default as VerifiedBadge } from "./VerifiedBadge";
-export {default as FontAwesome} from "./FrontAwesome";
+export { default as FontAwesome } from "./FontAwesome";

--- a/src/renderer/powercord/pluginmanager.ts
+++ b/src/renderer/powercord/pluginmanager.ts
@@ -239,6 +239,10 @@ export default class PluginManager extends Emitter {
         else this.enable(plugin);
     }
 
+    static get(name: string) {
+        return this.plugins.get(name);
+    }
+
     static get enable() {return this.enablePlugin;}
     static get disable() {return this.disablePlugin;}
     static get reload() {return this.reloadPlugin;}

--- a/src/renderer/styles/misc.scss
+++ b/src/renderer/styles/misc.scss
@@ -1,3 +1,19 @@
+.fab {
+    font-family: "Font Awesome 5 Pro" !important;
+}
+
+.fad {
+    font-family: "Font Awesome 5 Pro" !important;
+}
+
+.fal, .far {
+    font-family: "Font Awesome 5 Pro" !important;
+}
+
+.fa, .fas {
+    font-family: "Font Awesome 5 Pro" !important;
+}
+
 .pc-settings-divider {
     margin: 10px 0;
 }

--- a/src/renderer/ui/components/addonpanel.tsx
+++ b/src/renderer/ui/components/addonpanel.tsx
@@ -20,7 +20,7 @@ export async function sortAddons(addons: any[], order: "ascending" | "descending
             if (!query) return true;
             const {manifest} = addon;
             // Use String() wrapper for clever escaping
-            return ["name", "author", "description"].some(type => searchOptions[type] && ~String(manifest[type] ?? "").toLowerCase().indexOf(query));
+            return ["name", "author", "description"].some(type => searchOptions[type] && String(manifest[type] ?? "").toLowerCase().includes(query.toLowerCase()));
         })
         .sort((a, b) => {
             const first = a.manifest[sortBy] ?? "";
@@ -39,7 +39,7 @@ export function OverflowContextMenu({type: addonType}) {
 
     const [sortBy, searchOptions, order] = DataStore.useEvent("misc", () => [
         DataStore.getMisc(`${addonType}.sortBy`, "name"),
-        DataStore.getMisc(`${addonType}.searchOption`, {}),
+        DataStore.getMisc(`${addonType}.searchOption`, {author: true, name: true, description: true}),
         DataStore.getMisc(`${addonType}.order`, "descending")
     ]);
 
@@ -100,9 +100,9 @@ export function OverflowContextMenu({type: addonType}) {
                         key={"search-" + type}
                         id={"search-" + type}
                         label={type[0].toUpperCase() + type.slice(1)}
-                        checked={searchOptions[type] ?? true}
+                        checked={searchOptions[type]}
                         action={() => {
-                            DataStore.setMisc(void 0, `${addonType}.searchOption.${type}`, !(searchOptions[type] ?? true));
+                            DataStore.setMisc(void 0, `${addonType}.searchOption.${type}`, !(searchOptions[type]));
                         }}
                     />
                 ))}
@@ -118,7 +118,7 @@ export default function AddonPanel({manager, type}) {
     const [addons, setAddons] = React.useState(null);
     const [sortBy, searchOptions, order] = DataStore.useEvent("misc", () => [
         DataStore.getMisc(`${type}.sortBy`, "name"),
-        DataStore.getMisc(`${type}.searchOption`, {}),
+        DataStore.getMisc(`${type}.searchOption`, {author: true, name: true, description: true}),
         DataStore.getMisc(`${type}.order`, "descending")
     ]);
 
@@ -131,9 +131,9 @@ export default function AddonPanel({manager, type}) {
     React.useEffect(() => {
         sortAddons(
             Array.from(manager.addons),
-            order ?? "descending",
+            order,
             query,
-            searchOptions ?? {author: true, name: true, description: true},
+            searchOptions,
             sortBy
         ).then(addons => setAddons(addons));
     }, [query, manager, type, order, searchOptions, sortBy]);


### PR DESCRIPTION
- Fixes the search functionality under `pc-compat`'s "Plugins" tab - the search query is now lower-cased as well
- Applies the default search options for users that haven't modified such filters yet
- Implements 'FontAwesome' support
- Attempting to load data from a data store that is empty (i.e. doesn't have any object properties) now falls back to the given defaults (if any)
- Adds the `get` method to the Plugin Manager API which simply retrieves a plugin instance by it's given ID