### PR TITLE
Fix swc.wasm loading

### DIFF
--- a/src/renderer/powercord/compilers/jsx.ts
+++ b/src/renderer/powercord/compilers/jsx.ts
@@ -10,7 +10,7 @@ const loaderReplace = `const path = require('path').join(__dirname, 'wasm_bg.was
 
 const loaderReplacement = `
 module.exports.__promise__ = (async () => {
-    const binary = require("fs").readFileSync(require("path").join(PCCompatNative.getBasePath(), "lib/swc.wasm"));
+    const binary = require("fs").readFileSync(require("path").join(PCCompatNative.getBasePath(), "lib/swc.wasm"), {encoding: null});
     const wasmModule = await WebAssembly.instantiate(binary, imports);
     module.exports.__wasm = wasm = wasmModule.instance.exports;
 })();


### PR DESCRIPTION
Started getting this error earlier today, basically breaking pc-compat (dev) and not loading any plugins/etc.

````
kernel/packages/pc-compat/lib/swc.wasm.js:272 Uncaught (in promise) TypeError: WebAssembly.instantiate(): Argument 0 must be a buffer source or a WebAssembly.Module object
````

Discovered while debugging/investigating that the swc.wasm file was getting loaded as a string instead of a buffer.

````
kernel/packages/pc-compat/lib/swc.wasm.js:271 swc.wasm file loaded as string
````

I'm not sure why it's randomly? getting loaded as a string because the docs for `readFileSync` says that encoding should null by default and thus load as a buffer (and it was working fine before today), however explicitly setting encoding to null while reading swc.wasm makes it load as a buffer and fixes the issue on my end.

edit: should also add i'm on stable discord & main kernel branch